### PR TITLE
Added JvmStatic annotation and reused getToastInstance method

### DIFF
--- a/toasthandler/src/main/java/com/toastfix/toastcompatwrapper/ToastHandler.kt
+++ b/toasthandler/src/main/java/com/toastfix/toastcompatwrapper/ToastHandler.kt
@@ -9,30 +9,25 @@ import android.widget.Toast
  * ToastHandler Singleton for showing toast
  */
 object ToastHandler {
+
     /**
      * Method to show Toast
      */
+    @JvmStatic
     fun showToast(context: Context, message: String, length: Int) {
-        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.N_MR1) {
-            ToastCompat.makeText(
-                context,
-                message,
-                length
-            ).show()
-        } else {
-            Toast.makeText(context, message, length).show()
-        }
+        getToastInstance(context, message, length).show()
     }
 
     /**
      * Method to return Toast instance
      */
+    @JvmStatic
     fun getToastInstance(context: Context, message: String, length: Int): Toast {
         if (Build.VERSION.SDK_INT == Build.VERSION_CODES.N_MR1) {
             return ToastCompat.makeText(
                 context,
                 message,
-               length
+                length
             )
         } else {
             return Toast.makeText(context, message, length)


### PR DESCRIPTION
Added `@JvmStatic` annotation to ToastHandler methods.
- `fun showToast(context: Context, message: String, length: Int)`
- `fun getToastInstance(context: Context, message: String, length: Int)`

This will allow us to call these methods from Java without `INSTANCE`

```diff
- ToastHandler.INSTANCE.showToast(this, "Hello,I am Toast", Toast.LENGTH_SHORT);
+ ToastHandler.showToast(this, "Hello,I am Toast", Toast.LENGTH_SHORT);
```

Also, reused the `getToastInstance` method in `showToast` method as they were quite similar.